### PR TITLE
Don't cut the value on `change`

### DIFF
--- a/addon/components/masked-input.hbs
+++ b/addon/components/masked-input.hbs
@@ -2,7 +2,6 @@
   {{ref this "inputEl"}}
   ...attributes
   value={{this.displayValue}}
-  placeholder={{this.placeholder}}
   maxlength={{this.maxlength}}
   size={{this.size}}
   {{on 'keydown' (fn this.onInputKeyDown)}}

--- a/addon/components/masked-input.js
+++ b/addon/components/masked-input.js
@@ -58,10 +58,6 @@ export default class MaskedInputComponent extends Component {
     return this.pattern.length;
   }
 
-  get placeholder() {
-    return this.inputMask.emptyValue;
-  }
-
   get readonly() {
     return this.inputEl.readOnly;
   }

--- a/addon/components/masked-input.js
+++ b/addon/components/masked-input.js
@@ -74,13 +74,6 @@ export default class MaskedInputComponent extends Component {
   onInputChange(e) {
     const maskValue = this.inputMask.getValue();
     if (e.target.value !== maskValue) {
-      // Cut or delete operations will have shortened the value
-      if (e.target.value.length < maskValue.length) {
-        const sizeDiff = maskValue.length - e.target.value.length;
-        this.updateMaskSelection();
-        this.inputMask.selection.end = this.inputMask.selection.start + sizeDiff;
-        this.inputMask.backspace();
-      }
       const value = this.displayValue;
       e.target.value = value;
       if (value) {


### PR DESCRIPTION
Android does not support `keypress` which means when `change` runs, it will use the input and set the placeholders.
It doesn't solve the Android problem but it makes the input field usable.

In addition, cutting the value will erroneously remove an additional character:
Have a mask such as `111-11-1111` and enter `123-45-6789`. If you remove the `6` and leave the field, the cut will remove the ending character and will cause the input to be `123-45-_78_`. With the new change it will be `123-45-789_`.