### PR TITLE
Ignore modifications if input is readonly

### DIFF
--- a/addon/components/masked-input.js
+++ b/addon/components/masked-input.js
@@ -109,6 +109,10 @@ export default TextField.extend({
   },
 
   keyDown(e) {
+    // On Firefox, ignore any key if input is readonly
+    if (this.get('readonly')) {
+      return;
+    }
     let mask = this.get('_inputMask');
     if (isUndo(e)) {
       e.preventDefault();

--- a/addon/components/masked-input.js
+++ b/addon/components/masked-input.js
@@ -146,7 +146,8 @@ export default TextField.extend({
     // Ignore modified key presses
     // Ignore enter key to allow form submission
     // Ignore tab key to allow focussing other elements
-    if (e.metaKey || e.altKey || e.ctrlKey || e.keyCode === 13 || e.keyCode === 9) {
+    // On Firefox, ignore any key if input is readonly
+    if (e.metaKey || e.altKey || e.ctrlKey || e.keyCode === 13 || e.keyCode === 9 || this.get('readonly')) {
       return;
     }
 
@@ -162,6 +163,10 @@ export default TextField.extend({
   },
 
   paste(e) {
+    // On Firefox, ignore paste if input is readonly
+    if (this.get('readonly')) {
+      return;
+    }
     e.preventDefault();
     this._updateMaskSelection();
     // getData value needed for IE also works in FF & Chrome


### PR DESCRIPTION
Hello,
It seems that in Firefox, the `readonly` attribute is ignored (you can enter or paste text into it). The Keypress event is fired, whereas it is not in Chrome.
This PR just makes the masked input ignore key presses and text paste, when the readonly attribute is set.