### PR TITLE
Fix ref incompatibility with newer ember

### DIFF
--- a/addon/components/masked-input.hbs
+++ b/addon/components/masked-input.hbs
@@ -1,5 +1,5 @@
 <input
-  {{ref this "inputEl"}}
+  {{create-ref "inputEl"}}
   ...attributes
   value={{this.displayValue}}
   placeholder={{this.placeholder}}

--- a/addon/components/masked-input.js
+++ b/addon/components/masked-input.js
@@ -3,6 +3,7 @@ import { action } from "@ember/object";
 import { computed } from '@ember/object';
 import { next } from '@ember/runloop';
 
+import { ref } from 'ember-ref-bucket';
 import InputMask from 'inputmask-core';
 
 import { getSelection, setSelection } from '../util/selection';
@@ -23,7 +24,7 @@ const NOOP = function(){};
 
 export default class MaskedInputComponent extends Component {
   // Reference to the input element
-  inputEl = null;
+  @ref("inputEl") inputEl;
 
   // Dunno why tracking a getter doesn't work here - needs explicit arg dependencies to update correctly
   // Do not add value as dependency, since the input mask value will be set by the according actions.

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "ember-auto-import": "^1.5.3",
     "ember-cli-babel": "^7.17.2",
     "ember-cli-htmlbars": "^4.2.2",
-    "ember-ref-modifier": "^1.0.0",
+    "ember-ref-bucket": "^4.1.0",
     "inputmask-core": "^2.1.1"
   },
   "devDependencies": {


### PR DESCRIPTION
ember-ref-modifier is unsupported in favor of ember-ref-bucket. This change is enough to get things working on ember 3.28 for me.

This change probably bumps the minimum supported ember version for this library to 3.20, since that is the oldest ember-ref-bucket supports.

Also, fellow app upgraders should take care that they aren't getting multiple conflicting copies of ember-modifier, because a newer version of ember-modifier will come as a dependency of ember-ref-bucket. In my case it was necessary to use yarn resolutions to put everything onto ember-modifier ^3.0.0.