### PR TITLE
added changes to make the input work correctly on Android

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 /node_modules/
 
 # misc
+/.idea/
 /.env*
 /.pnp*
 /.sass-cache
@@ -24,6 +25,7 @@
 /.node_modules.ember-try/
 /bower.json.ember-try
 /package.json.ember-try
+/package-lock.json
 
 *.sublime-workspace
 yarn.lock

--- a/addon/components/masked-input.hbs
+++ b/addon/components/masked-input.hbs
@@ -9,4 +9,5 @@
   {{on 'keypress' (fn this.onInputKeyPress)}}
   {{on 'change' (fn this.onInputChange)}}
   {{on 'paste' (fn this.onInputPaste)}}
+  {{on "beforeinput" this.onInputBeforeInput}}
 />

--- a/addon/components/masked-input.js
+++ b/addon/components/masked-input.js
@@ -75,6 +75,7 @@ export default class MaskedInputComponent extends Component {
   onInputChange(e) {
     const maskValue = this.inputMask.getValue();
     if (e.target.value !== maskValue) {
+      this.inputMask.setValue(e.target.value);
       // Cut or delete operations will have shortened the value
       if (e.target.value.length < maskValue.length) {
         const sizeDiff = maskValue.length - e.target.value.length;
@@ -138,15 +139,8 @@ export default class MaskedInputComponent extends Component {
     if (e.metaKey || e.altKey || e.ctrlKey || e.keyCode === 13 || e.keyCode === 9 || this.readonly) {
       return;
     }
-
-    e.preventDefault();
-    this.updateMaskSelection();
     const key = e.key || String.fromCharCode(e.charCode);
-    if (this.inputMask.input(key)) {
-      e.target.value = this.inputMask.getValue();
-      this.updateInputSelection();
-      this.onChange(e);
-    }
+    this.handleCharInput(e, key)
   }
 
   @action
@@ -167,6 +161,22 @@ export default class MaskedInputComponent extends Component {
       next(this, this.updateInputSelection);
       this.onChange(e);
     }
+  }
+
+  @action
+  handleCharInput(evt, key) {
+    evt.preventDefault();
+    this.updateMaskSelection();
+    if (this.inputMask.input(key)) {
+      evt.target.value = this.inputMask.getValue();
+      this.updateInputSelection();
+      this.onChange(evt);
+    }
+  }
+
+  @action
+  onInputBeforeInput(evt) {
+    this.handleCharInput(evt, evt.data);
   }
 
   updateMaskSelection() {


### PR DESCRIPTION
This change uses the before input as a proxy for keypress that allows for Android input to work.   Currently when you attempt to type in the input while in Android - the values do not get updated and the mask does not get displayed on input text types.  If you use a tel or num type it seems to work.  But text types do not receive events correctly.

Testing needs to happen on Browserstack or on a physical device so I do not have an automated way of doing this - but regressions do not seem to be a problem. 